### PR TITLE
Update to new supportedVersion syntax, +1.0

### DIFF
--- a/About/About-Debug.xml
+++ b/About/About-Debug.xml
@@ -2,7 +2,11 @@
 <ModMetaData>
 	<name>FinishTheDamnThing - Dev Build</name>
 	<author>L0laapk3</author>
-	<targetVersion>0.18.1722</targetVersion>
+	<supportedVersions>
+		<li>0.18</li>
+		<li>0.19</li>
+		<li>1.0</li>
+	</supportedVersions>
 	<description>Lets everyone finish eachothers unfinished bills 
 (This is the dev version of FinishTheDamnThing. The release version of About.xml is available for editing at About/About-Release.xml. Edits made on this file or on the temporary About/About.xml won't show up on the release version. Use VisualStudio to build a "Release" version of this mod when ready to upload your mod!)</description>
 	<url>https://steamcommunity.com/id/L0laapk3/myworkshopfiles/?appid=294100</url>

--- a/About/About-Release.xml
+++ b/About/About-Release.xml
@@ -2,7 +2,11 @@
 <ModMetaData>
 	<name>FinishTheDamnThing</name>
 	<author>L0laapk3</author>
-	<targetVersion>0.18.1722</targetVersion>
+	<supportedVersions>
+		<li>0.18</li>
+		<li>0.19</li>
+		<li>1.0</li>
+	</supportedVersions>
 	<description>Lets everyone finish eachothers unfinished bills</description>
 	<url>https://steamcommunity.com/id/L0laapk3/myworkshopfiles/?appid=294100</url>
 </ModMetaData>


### PR DESCRIPTION
Updates the About.xml config to use the new supportedVersions syntax.
This allows the mod to work with 0.18, 0.19, and 1.0.

Closes L0laapk3/RimWorld_FinishTheDamnThing#1.